### PR TITLE
draft: esm source design

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,10 @@ an `AbstractModuleSource` one has already passed the CSP policy checks.
 For JavaScript, CSP integration similarly occurs statically before execution, where having `source`
 phase import handle to a JS `ModuleSource` implies the CSP permission to execute that source.
 
+For `new Worker(module)`, the CSP policy would need to determine the `src` for the module to check
+against. In this case, it should be possible to recreate the original CSP `src` from the
+`[[HostDefined]]` data, without needing any explicit ECMA-262 integration.
+
 ### Structured Clone
 
 A `ModuleSource` instance can be supportable in structured clone, since the underlying


### PR DESCRIPTION
This outlines an initial design sketch for the ESM source phase design, covering:

* `module.exports()` and `module.imports()` APIs
* Internal slot for resolution
* Dynamic `import()` integration rules
* Integration with other specifications such as CSP and structured clone

In an initial version I explicitly defined the CSP property for a `[[HostSrc]]` internal slot that might be directly checked in the CSP policy rules for example in the [Wasm ESM integration](https://www.w3.org/TR/CSP3/#wasm-integration).

But on further consideration, CSP as a compilation check, means that by having a source phase import that the compilation guard has already passed - thus if you have a handle to a concrete `AbstractModuleSource`, then it's already passed through CSP. Similarly for JS, dynamic import of a module guards the module at fetch time, not execution time.

Therefore, it is only the `new Worker(module)` invocation that needs to be supported here from a CSP perspective as a new construct for permitting CSP sources that have already been vetted statically.

Then I think for that case that we can rather define that the `src` can be reconstructed from `[[HostDefined]]` in order to perform the verification here. If there are difficulties figuring that out, then I think that is a CSP integration problem we should handle when we get there, but that we don't necessarily need right now to introduce new machinery to handle it without trying the simpler approach first.